### PR TITLE
Fix OS boot failure

### DIFF
--- a/guest/bios_os_loader.c
+++ b/guest/bios_os_loader.c
@@ -17,7 +17,6 @@ VOID EnterRealModeRunFunction(IN BYTE function, OUT BYTE_PTR* outputBuffer)
     CopyMemory((QWORD_PTR)REAL_MODE_CODE_START + enterRealModeLength, 
                functionBegin, 
                functionLeanth);
-    Print("Code: %.b\n", enterRealModeLength, REAL_MODE_CODE_START);
     AsmEnterRealModeRunFunction();
 
     if(outputBuffer != NULL)
@@ -34,7 +33,7 @@ VOID ReadFirstSectorToRam(IN BYTE diskIndex, OUT BYTE_PTR* address)
     packet->dest = FIRST_SECTOR_DEST;
     packet->sectorNumberLowPart = 0;
     packet->sectorNumberHighPart = 0;
-    CopyMemory(DAP_ADDRESS + sizeof(DISK_ADDRESS_PACKET), &diskIndex, sizeof(BYTE));
+    CopyMemory(DAP_ADDRESS + 0x10, &diskIndex, sizeof(BYTE));
     EnterRealModeRunFunction(DISK_READER, NULL);
     *address = FIRST_SECTOR_DEST;
 }

--- a/guest/bios_os_loader.c
+++ b/guest/bios_os_loader.c
@@ -19,7 +19,7 @@ VOID EnterRealModeRunFunction(IN BYTE function, OUT BYTE_PTR* outputBuffer)
                functionLeanth);
     AsmEnterRealModeRunFunction();
 
-    if(outputBuffer != NULL)
+    if(outputBuffer)
         outputBuffer = (BYTE_PTR)REAL_MODE_OUTPUT_BUFFER_ADDRESS;
 }
 
@@ -35,6 +35,11 @@ VOID ReadFirstSectorToRam(IN BYTE diskIndex, OUT BYTE_PTR* address)
     packet->sectorNumberHighPart = 0;
     *(BYTE_PTR)(DAP_ADDRESS + 0x10) = diskIndex;
     EnterRealModeRunFunction(DISK_READER, NULL);
+    if(!address)
+    {
+        Print("Output address was not specified as a destenation for int 13h\n");
+        ASSERT(FALSE);
+    }
     *address = FIRST_SECTOR_DEST;
 }
 
@@ -45,9 +50,10 @@ VOID LoadMBRToEntryPoint()
     for(BYTE diskIdx = 0x80; diskIdx < 0xff; diskIdx++)
     {
         ReadFirstSectorToRam(diskIdx, &sectorAddress);
-        if(*(WORD_PTR)((BYTE_PTR)sectorAddress + 510) == BOOTABLE_SIGNATURE)
+        if(*(WORD_PTR)((BYTE_PTR)sectorAddress + MBR_SIZE - sizeof(WORD)) == BOOTABLE_SIGNATURE)
         {
-            CopyMemory(MBR_ADDRESS, sectorAddress, 512;
+            Print("An MBR disk was found at disk #%d\n", diskIdx);
+            CopyMemory(MBR_ADDRESS, sectorAddress, MBR_SIZE);
             *(BYTE_PTR)(WINDOWS_DISK_INDEX) = diskIdx;
             break;
         }

--- a/guest/bios_os_loader.c
+++ b/guest/bios_os_loader.c
@@ -29,11 +29,11 @@ VOID ReadFirstSectorToRam(IN BYTE diskIndex, OUT BYTE_PTR* address)
     packet->size = 0x10;
     packet->reserved = 0;
     packet->count = 1;
-    packet->offset = 0;
-    packet->dest = FIRST_SECTOR_DEST;
+    packet->offset = FIRST_SECTOR_DEST;
+    packet->segment = 0;
     packet->sectorNumberLowPart = 0;
     packet->sectorNumberHighPart = 0;
-    CopyMemory(DAP_ADDRESS + 0x10, &diskIndex, sizeof(BYTE));
+    *(BYTE_PTR)(DAP_ADDRESS + 0x10) = diskIndex;
     EnterRealModeRunFunction(DISK_READER, NULL);
     *address = FIRST_SECTOR_DEST;
 }
@@ -45,9 +45,9 @@ VOID LoadMBRToEntryPoint()
     for(BYTE diskIdx = 0x80; diskIdx < 0xff; diskIdx++)
     {
         ReadFirstSectorToRam(diskIdx, &sectorAddress);
-        if(sectorAddress->magic == BOOTABLE_SIGNATURE)
+        if(*(WORD_PTR)((BYTE_PTR)sectorAddress + 510) == BOOTABLE_SIGNATURE)
         {
-            CopyMemory(MBR_ADDRESS, sectorAddress, sizeof(MBR));
+            CopyMemory(MBR_ADDRESS, sectorAddress, 512;
             *(BYTE_PTR)(WINDOWS_DISK_INDEX) = diskIdx;
             break;
         }

--- a/host/entrypoint.asm
+++ b/host/entrypoint.asm
@@ -123,21 +123,19 @@ _start:
     add edi, 8
     add eax, LARGE_PAGE_SIZE
     loop .setup_pds
-
     ; At this point I am allowed to work with addresses from 0 to 3GB
 
     ; Set gdt
     mov eax, 0x1000 ; gdt
-    mov word [eax], 0xff ; limit
-    mov dword [eax + 2], 0x2000
+    mov word [eax], 0x00ff ; limit
+    MovQwordToAddressLittleEndian 0x1002, 0x0, 0x2000
     ; left = high part, right = low part. For more information, read AMD64 developer manual volume 2, GDT
     MovQwordToAddressLittleEndian 0x2000, 0x0, 0x0 ; null descriptor - 0
-    MovQwordToAddressLittleEndian 0x2008, 0x209f00, 0x0 ; code - long mode - 8
-    MovQwordToAddressLittleEndian 0x2010, 0x9000, 0x0 ; data - long mode - 16
-    MovQwordToAddressLittleEndian 0x2018, 0x4f9e00, 0xffff ; code - 32 bit mode - 24
-    MovQwordToAddressLittleEndian 0x2020, 0x9a00, 0xffff ; code - 16 bit mode - 32
-    MovQwordToAddressLittleEndian 0x2028, 0xcf9200, 0xffff ; data - 32 bit mode - 40
-    MovQwordToAddressLittleEndian 0x2030, 0x9200, 0xffff ; data - 16 bit mode - 48
+	MovQwordToAddressLittleEndian 0x2008, 0x209a00, 0x0	; code - long mode - 8
+	MovQwordToAddressLittleEndian 0x2010, 0xcf9200, 0xffff ; data - long and compatibility - 16
+	MovQwordToAddressLittleEndian 0x2018, 0xcf9a00, 0xffff ; data - 32-bit mode - 24
+	MovQwordToAddressLittleEndian 0x2020, 0x9a00, 0xffff ; code - 16 bit (not real) - 32
+	MovQwordToAddressLittleEndian 0x2028, 0x9200, 0xffff ; data - 16 bit (not real) - 40
     lgdt [0x1000]
 
     ; Enter long mode - see docs/host/entrypoint.md for details
@@ -157,26 +155,26 @@ _start:
     mov cr0, eax
     ; The CPU is now in compatibility mode.
     ; Still need to load the GDT with the 64-bit flags set in the code and data selectors.
+
     jmp 8:CompatibilityTo64
 
 ; 64-bit code goes here
 [BITS 64]
 CompatibilityTo64:
     cli
-    ;mov ax, 8
-    ;mov cs, ax
-    ; mov ax, 16    
-    ; mov ss, ax
-    ; mov es, ax
-    ; mov ds, ax
-                                
+    mov ax, 16    
+    mov ss, ax
+    mov es, ax
+    mov ds, ax
+    mov fs, ax
+    mov gs, ax
+
     mov rcx, COMPUTER_MEM_SIZE  ; map ALL available memory
     shl rcx, 9                  ; multiply by 512
     xor rax, rax                ; start address is 0
-    mov rbx, ((1 << 7) | (1 << 1) | 1)
+    or rax, ((1 << 7) | (1 << 1) | 1)
     mov rdi, 0x19000
 .setup_pds_long_mode:
-    or rax, rbx
     mov qword [rdi], rax
     add rdi, 8
     add rax, LARGE_PAGE_SIZE
@@ -193,21 +191,29 @@ CompatibilityTo64:
 [BITS 32]
 SetupSystemAndHandleControlToBios:
     ; define the interrupt vector for real mode
-    mov ax, 40
+    mov ax, 24
     mov ss, ax
     mov ds, ax
     mov es, ax
+    mov gs, ax
+    mov fs, ax
+
     mov eax, IVT_ADDRESS ; ivt
     mov word [eax], 0xff ; limit
     mov dword [eax + 2], 0x0 ; ivt address (0)
+    mov dword [eax + 6], 0x0
+    lidt [IVT_ADDRESS]
     jmp 32:(SetupSystemAndHandleControlToBiosEnd - SetupRealMode + REAL_MODE_CODE_START)
 
 [BITS 16]
 SetupRealMode:
-    mov ax, 48
+    mov ax, 40
     mov ss, ax
     mov ds, ax
     mov es, ax
+    mov gs, ax
+    mov fs, ax
+
     mov eax, cr0
     and eax, ~(1 | (1 << 31)) ; Disable paging & PM
     mov cr0, eax
@@ -223,10 +229,12 @@ SetupRealMode:
 HandleControlToBios:
     mov dl, [WINDOWS_DISK_INDEX]
     mov ax, 0
-    mov cs, ax
     mov ds, ax
     mov es, ax
     mov ss, ax
+    mov fs, ax
+    mov gs, ax
+
     jmp 0:MBR_ADDRESS
 HandleControlToBiosEnd:
 SetupSystemAndHandleControlToBiosEnd:

--- a/host/entrypoint.asm
+++ b/host/entrypoint.asm
@@ -133,7 +133,7 @@ _start:
     MovQwordToAddressLittleEndian 0x2000, 0x0, 0x0 ; null descriptor - 0
 	MovQwordToAddressLittleEndian 0x2008, 0x209a00, 0x0	; code - long mode - 8
 	MovQwordToAddressLittleEndian 0x2010, 0xcf9200, 0xffff ; data - long and compatibility - 16
-	MovQwordToAddressLittleEndian 0x2018, 0xcf9a00, 0xffff ; data - 32-bit mode - 24
+	MovQwordToAddressLittleEndian 0x2018, 0xcf9a00, 0xffff ; code - 32-bit mode - 24
 	MovQwordToAddressLittleEndian 0x2020, 0x9a00, 0xffff ; code - 16 bit (not real) - 32
 	MovQwordToAddressLittleEndian 0x2028, 0x9200, 0xffff ; data - 16 bit (not real) - 40
     lgdt [0x1000]

--- a/include/debug.h
+++ b/include/debug.h
@@ -9,7 +9,7 @@
 #define COM4 0x2E8
 #define DEBUG_PORT COM3
 
-#define BUFF_MAX_SIZE 0x500
+#define BUFF_MAX_SIZE 0x1000
 
 VOID PrintBuffer(IN PCHAR buffer, IN QWORD length);
 VOID PrintNullTerminatedBuffer(IN PCHAR buffer);

--- a/include/guest/bios_os_loader.h
+++ b/include/guest/bios_os_loader.h
@@ -17,7 +17,7 @@ enum{
     GET_MEMORY_MAP = 1
 };
 
-typedef struct _DISK_ADDRESS_PACKET
+typedef struct __attribute__((__packed__)) _DISK_ADDRESS_PACKET 
 {
     BYTE size;
     BYTE reserved;

--- a/include/guest/bios_os_loader.h
+++ b/include/guest/bios_os_loader.h
@@ -12,6 +12,8 @@
 #define REAL_MODE_CODE_START 0x4200
 #define WINDOWS_DISK_INDEX 0x6010
 
+#define MBR_SIZE 512 
+
 enum{
     DISK_READER = 0,
     GET_MEMORY_MAP = 1

--- a/include/guest/bios_os_loader.h
+++ b/include/guest/bios_os_loader.h
@@ -7,7 +7,7 @@
 #define MBR_ADDRESS 0x7c00
 #define DAP_ADDRESS 0x4000
 #define FIRST_SECTOR_DEST 0x3000
-#define BOOTABLE_SIGNATURE 0x55aa
+#define BOOTABLE_SIGNATURE 0xAA55
 #define REAL_MODE_OUTPUT_BUFFER_ADDRESS 0x2200
 #define REAL_MODE_CODE_START 0x4200
 #define WINDOWS_DISK_INDEX 0x6010
@@ -17,16 +17,16 @@ enum{
     GET_MEMORY_MAP = 1
 };
 
-typedef struct __attribute__((__packed__)) _DISK_ADDRESS_PACKET 
+typedef struct _DISK_ADDRESS_PACKET 
 {
     BYTE size;
     BYTE reserved;
     WORD count;
     WORD offset;
-    WORD dest;
+    WORD segment;
     DWORD sectorNumberLowPart;
     DWORD sectorNumberHighPart;
-}DISK_ADDRESS_PACKET, *PDISK_ADDRESS_PACKET;
+} __attribute__((__packed__)) DISK_ADDRESS_PACKET, *PDISK_ADDRESS_PACKET;
 
 typedef struct _PARTITION_TABLE_ENTRY
 {
@@ -36,7 +36,7 @@ typedef struct _PARTITION_TABLE_ENTRY
     BYTE CHSLastAddress[3];
     DWORD firstSectorLBA;
     DWORD sectorsCount;
-}PARTITION_TABLE_ENTRY, *PPARTITION_TABLE_ENTRY;
+} __attribute__((__packed__)) PARTITION_TABLE_ENTRY, *PPARTITION_TABLE_ENTRY;
 
 typedef struct _MBR
 {
@@ -45,7 +45,7 @@ typedef struct _MBR
     WORD reserved;
     PARTITION_TABLE_ENTRY partitionTable[4];
     WORD magic;
-}MBR, *PMBR;
+}__attribute__((__packed__))  MBR, *PMBR;
 
 typedef VOID (*BiosFunction)();
 

--- a/shared/real_mode_functions.asm
+++ b/shared/real_mode_functions.asm
@@ -16,7 +16,7 @@
 
 %macro SetCr3BasePhysicalAddress 1
 	mov eax, %1
-    mov cr3, eax ; need to test - not sure about it, what happens to the 32 MSBs?
+    mov cr3, eax
 %endmacro
 
 %macro MovQwordToAddressLittleEndian 3
@@ -53,7 +53,7 @@ AsmEnterRealModeRunFunction:
 	pushf
 	push 24
 	push REAL_MODE_CODE_START
-	iretq
+	iretq   ; jmp with selector is not supported in long mode, use IRET instead
 AsmReturnFromRealModeFunction:
     cli
     mov ax, 16
@@ -151,6 +151,7 @@ DiskReader:
     mov ds, ax
     mov fs, ax
     mov gs, ax
+    
     xor eax, eax
     mov si, DAP_ADDRESS
     mov ah, 0x42

--- a/shared/real_mode_functions.asm
+++ b/shared/real_mode_functions.asm
@@ -103,25 +103,22 @@ DisableLongMode:
 
 BackToLongMode:
     cli
-    OutputSerial 'S'
-    lgdt [0x6000]
+    lgdt [0x1000]
     mov ax, 0
     mov ss, ax
     mov ds, ax
     mov es, ax
     mov fs, ax
     mov gs, ax
-
+    
     mov eax, cr0
     or eax, 1
     mov cr0, eax ; the system is now in the same state as it was at boot time
     ; Enable long mode when back from handling interrupts
-    OutputSerial 'R'
     jmp 24:(EnableProtectedMode - EnterRealMode + REAL_MODE_CODE_START)
 
 [BITS 32]
 EnableProtectedMode:
-    OutputSerial 'C'
     cli
     mov ax, 16
     mov ss, ax
@@ -129,7 +126,6 @@ EnableProtectedMode:
     mov es, ax
     mov gs, ax
     mov fs, ax
-
     mov eax, cr0
     and eax, ~(1 << 31)
     mov cr0, eax
@@ -155,7 +151,6 @@ DiskReader:
     mov ds, ax
     mov fs, ax
     mov gs, ax
-    
     xor eax, eax
     mov si, DAP_ADDRESS
     mov ah, 0x42


### PR DESCRIPTION
Fix OS boot failure, including:

* Wrong descriptors
* Wrong magic field in MBR (big endian instead little endian)
* Wrong selectors in real/protected (32-bit)

AND NOW WINDOWS BOOTS!