### PR TITLE
Fix Windows boot issues

### DIFF
--- a/native-hypervisor/include/debug.h
+++ b/native-hypervisor/include/debug.h
@@ -18,7 +18,9 @@
 #define DEBUG_LVL_WARNING 2
 #define DEBUG_LVL_INFO 1
 #define DEBUG_LVL DEBUG_LVL_DEBUG
+
 // #define DEBUG_ADDRESS_TRANSLATION
+// #define DEBUG_XSETBV
 
 VOID PrintBuffer(IN PCHAR buffer, IN QWORD length);
 VOID PrintNullTerminatedBuffer(IN PCHAR buffer);

--- a/native-hypervisor/include/vmm/control_fields.h
+++ b/native-hypervisor/include/vmm/control_fields.h
@@ -27,6 +27,7 @@
 #define CPU_BASED_CTL2_ENABLE_EPT           0x2
 #define CPU_BASED_CTL2_RDTSCP               0x8
 #define CPU_BASED_CTL2_ENABLE_VPID          0x20
+#define CPU_BASED_CTL2_ENABLE_INVPCID       (1 << 12)
 #define CPU_BASED_CTL2_UNRESTRICTED_GUEST   0x80
 #define CPU_BASED_CTL2_ENABLE_VMFUNC        0x2000
 
@@ -36,8 +37,9 @@
 #define VM_ENTRY_SMM                    0x00000400
 #define VM_ENTRY_DEACT_DUAL_MONITOR     0x00000800
 #define VM_ENTRY_LOAD_GUEST_PAT         0x00004000
-
+#define VM_ENTRY_LOAD_EFER              (1 << 15)
 // VM-exit controls
+#define VM_EXIT_LOAD_DEBUG_CTLS         (1 << 2)
 #define VM_EXIT_IA32E_MODE              0x00000200
 #define VM_EXIT_ACK_INTR_ON_EXIT        0x00008000
 #define VM_EXIT_SAVE_GUEST_PAT          0x00040000

--- a/native-hypervisor/include/x86_64.h
+++ b/native-hypervisor/include/x86_64.h
@@ -19,6 +19,8 @@
 
 /* CPUID related data */
 #define CPUID_XSAVE (1 << 26)
+#define CPUID_OSXSAVE (1 << 27)
+#define CPUID_XSTATE_LEAF 0xd
 
 /* Useful opcodes */
 #define INT3_OPCODE 0xcc

--- a/native-hypervisor/vmm/vmm.c
+++ b/native-hypervisor/vmm/vmm.c
@@ -124,7 +124,7 @@ VOID InitializeSingleHypervisor(IN PVOID data)
     __vmwrite(HOST_SYSENTER_EIP, 0xffffffff);
     __vmwrite(HOST_SYSENTER_ESP, 0xffffffff);
     __vmwrite(HOST_GDTR_BASE, cpuData->gdt);
-    
+
     // General
     __vmwrite(VMCS_LINK_POINTER, -1ULL);
     __vmwrite(TSC_OFFSET, 0);
@@ -136,12 +136,14 @@ VOID InitializeSingleHypervisor(IN PVOID data)
     __vmwrite(VM_ENTRY_MSR_LOAD_COUNT, 0);
     __vmwrite(VM_ENTRY_INTR_INFO, 0);
     __vmwrite(CPU_BASED_VM_EXEC_CONTROL, AdjustControls(CPU_BASED_ACTIVATE_MSR_BITMAP | CPU_BASED_ACTIVATE_SECONDARY_CONTROLS, MSR_IA32_VMX_PROCBASED_CTLS));
-	__vmwrite(SECONDARY_VM_EXEC_CONTROL, AdjustControls(CPU_BASED_CTL2_ENABLE_EPT | CPU_BASED_CTL2_UNRESTRICTED_GUEST, MSR_IA32_VMX_PROCBASED_CTLS2));
+	__vmwrite(SECONDARY_VM_EXEC_CONTROL, AdjustControls(CPU_BASED_CTL2_ENABLE_INVPCID | CPU_BASED_CTL2_RDTSCP  | CPU_BASED_CTL2_ENABLE_EPT | CPU_BASED_CTL2_UNRESTRICTED_GUEST, MSR_IA32_VMX_PROCBASED_CTLS2));
     __vmwrite(PIN_BASED_VM_EXEC_CONTROL, AdjustControls(0, MSR_IA32_VMX_PINBASED_CTLS));
-	__vmwrite(VM_EXIT_CONTROLS, AdjustControls(VM_EXIT_IA32E_MODE | VM_EXIT_ACK_INTR_ON_EXIT, MSR_IA32_VMX_EXIT_CTLS));
-	__vmwrite(VM_ENTRY_CONTROLS, AdjustControls(VM_ENTRY_IA32E_MODE | VM_ENTRY_LOAD_DEBUG_CTLS, MSR_IA32_VMX_ENTRY_CTLS));
+	__vmwrite(VM_EXIT_CONTROLS, AdjustControls(VM_EXIT_SAVE_EFER | VM_EXIT_LOAD_EFER | VM_EXIT_IA32E_MODE, MSR_IA32_VMX_EXIT_CTLS));
+	__vmwrite(VM_ENTRY_CONTROLS, AdjustControls(VM_ENTRY_LOAD_EFER | VM_ENTRY_IA32E_MODE, MSR_IA32_VMX_ENTRY_CTLS));
     __vmwrite(EPT_POINTER, InitializeExtendedPageTable(cpuData));
     __vmwrite(MSR_BITMAP, VirtualToPhysical(cpuData->msrBitmaps));
+    __vmwrite(VIRTUAL_PROCESSOR_ID, 1);
+    
     // Register all handlers
     RegisterVmExitHandlers(cpuData);
 


### PR DESCRIPTION
During the boot process of Windows 10, I faced a few issues:

* The execution of `INVPCID` and `RDTSCP` was not permitted due to a misconfiguration of the VMCS (CPU_BASED_CTL2 field).
* Windows ran into an endless loop due to the result it received from `cpuid` with the XSTATE leaf. 

The first issue was discovered by changing the VMCS initialization according to [this article](https://rayanfam.com/topics/hypervisor-from-scratch-part-5/).
The second issue was discovered while debugging the system using VMware and gdb.
